### PR TITLE
Update README with Truco Mineiro Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 ### Database Migrations
 For information about working with database migrations, see the [Alembic README](src/external/alembic/README).
 
+
 ## Run unit tests 🧪
 ```bash
 poetry run pytest tests/
@@ -278,58 +279,3 @@ A hand with Truco is worth 4 points, with increments of 4 points if raised.
 The first team to reach 12 points wins the game.
 
 The game does not include Envido or Flor.
-
-# React + TypeScript + Vite
-
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
-```


### PR DESCRIPTION
This pull request updates the README file to include a section explaining the specific rules of Truco Mineiro. This will help new developers understand the game mechanics and scoring rules.

### Added Section:
- **Truco Mineiro Rules**:
  - The game uses a 40-card deck (8s, 9s, and 10s removed).
  - The card ranking is as follows:
    1. 4 of Clubs (Zap)
    2. 7 of Hearts (Copas)
    3. Ace of Spades (Espadão)
    4. 7 of Diamonds (Espadinha)
    5. 3s, 2s, Aces, Kings, Jacks, Queens, 7 of Spades, 7 of Clubs, 6s, 5s, 4s
  - A regular hand is worth 2 points.
  - A hand with Truco is worth 4 points, with increments of 4 points if raised.
  - The first team to reach 12 points wins the game.
  - The game does not include Envido or Flor.